### PR TITLE
[ORCA-4810] Dynamic Route To Support in EventOrchestrationPathRuleActions

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -53,6 +53,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
+	DynamicRouteTo             *EventOrchestrationPathDynamicRouteTo              `json:"dynamic_route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
@@ -64,6 +65,12 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+}
+
+type EventOrchestrationPathDynamicRouteTo struct {
+	Source   string `json:"source,omitempty"`
+	Regex    string `json:"regex,omitempty"`
+	LookupBy string `json:"lookup_by,omitempty"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -515,7 +515,7 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
@@ -535,6 +535,17 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 				{
 					ID: "start",
 					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{
+									Source:   "event.summary",
+									Regex:    "service name: (.*)",
+									LookupBy: "service_name",
+								},
+							},
+							Conditions: []*EventOrchestrationPathRuleCondition{},
+							ID:         "E-ORC-DYNAMIC-RULE",
+						},
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								RouteTo: "P3ZQXDF",


### PR DESCRIPTION
This PR adds support for Dynamic Route To on the Router Event Orchestration path. 

#### Changes:

1. Added new `EventOrchestrationPathDynamicRouteTo` struct which includes Source, Regex and LookupBy properties.
2. Added this new property to existing `EventOrchestrationPathRuleActions` struct.
3. Updated test in `pagerduty/event_orchestration_path_test.go` for new action type
