### PR TITLE
Orca 4805/add escalation policy support

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           *EventOrchestrationPathEscalationPolicy            `json:"escalation_policy"`
+	EscalationPolicy           string                                             `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {
@@ -77,10 +77,6 @@ type EventOrchestrationPathDynamicRouteTo struct {
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 	ID    string `json:"id,omitempty"`
 	Value string `json:"value,omitempty"`
-}
-
-type EventOrchestrationPathEscalationPolicy struct {
-	EscalationPolicy string `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,6 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+	EscalationPolicy           *EventOrchestrationPathEscalationPolicy            `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {
@@ -76,6 +77,10 @@ type EventOrchestrationPathDynamicRouteTo struct {
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 	ID    string `json:"id,omitempty"`
 	Value string `json:"value,omitempty"`
+}
+
+type EventOrchestrationPathEscalationPolicy struct {
+	EscalationPolicy string `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           string                                             `json:"escalation_policy,omitempty"`
+	EscalationPolicy           string                                             `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -506,7 +506,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		},
 	}
 
-	var url = fmt.Sprintf("%s/E-ORC-1/router", eventOrchestrationBaseUrl)
+	var url = fmt.Sprintf("%s/E-ORC-1/global", eventOrchestrationBaseUrl)
 
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -515,16 +515,16 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{ "orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
+		w.Write([]byte(`{ "orchestration_path": { "type": "global", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
 	})
-	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
+	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeGlobal, input)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := &EventOrchestrationPathPayload{
 		OrchestrationPath: &EventOrchestrationPath{
-			Type: "router",
+			Type: "global",
 			Parent: &EventOrchestrationPathReference{
 				ID:   "E-ORC-1",
 				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -494,7 +494,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
+func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
@@ -515,9 +515,8 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}}, {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{ "orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
 	})
-
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
 	if err != nil {
 		t.Fatal(err)
@@ -539,7 +538,61 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 							Actions: &EventOrchestrationPathRuleActions{
 								EscalationPolicy: "POLICY",
 							},
+							ID: "E-ORC-EP-RULE",
 						},
+					},
+				},
+			},
+		},
+		Warnings: nil,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &EventOrchestrationPath{
+		Type: "router",
+		Parent: &EventOrchestrationPathReference{
+			ID:   "E-ORC-1",
+			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+			Type: "event_orchestration_reference",
+		},
+	}
+
+	var url = fmt.Sprintf("%s/E-ORC-1/router", eventOrchestrationBaseUrl)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationPathPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+	})
+
+	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "router",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -515,7 +515,7 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}}, {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
@@ -535,6 +535,11 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 				{
 					ID: "start",
 					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								EscalationPolicy: "POLICY",
+							},
+						},
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -498,7 +498,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
-		Type: "router",
+		Type: "global",
 		Parent: &EventOrchestrationPathReference{
 			ID:   "E-ORC-1",
 			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",


### PR DESCRIPTION
For orca 4805. 

There is now the added ability to define a custom escalation policy in the action section of rules. See: https://github.com/PagerDuty/captains-log/pull/1275/files#diff-2562ffb62b6490d1bc5eb3aa09a29d69e4955e707f20d88fc0adb33e3b1b0188R66

There will be followup work for this in the terraform provider