### PR TITLE
Orca 4806/update escalation policy type

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           string                                             `json:"escalation_policy"`
+	EscalationPolicy           *string                                            `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -522,6 +522,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	policy := "POLICY"
 	want := &EventOrchestrationPathPayload{
 		OrchestrationPath: &EventOrchestrationPath{
 			Type: "global",
@@ -536,7 +537,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 					Rules: []*EventOrchestrationPathRule{
 						{
 							Actions: &EventOrchestrationPathRuleActions{
-								EscalationPolicy: "POLICY",
+								EscalationPolicy: &policy,
 							},
 							ID: "E-ORC-EP-RULE",
 						},


### PR DESCRIPTION
We need to allow null and empty string so the EscalationPolicy should be a `*string`